### PR TITLE
Added trending topics list to current day post component

### DIFF
--- a/src/components/InformationButton/styles.js
+++ b/src/components/InformationButton/styles.js
@@ -6,7 +6,6 @@ export const Link = styled.a`
     display: block;
     width: fit-content;
     padding: 1vw 2vw 1vw 2vw;
-    margin-top: 4vh;
     &:hover{
         text-decoration: underline  ;
         color: white;

--- a/src/pages/CurrentDayPost/CurrentDayPost.tsx
+++ b/src/pages/CurrentDayPost/CurrentDayPost.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { PostContent, DateIndicator, TwitterData, VideoData, NewsData } from './styles';
+import { PostContent, DateIndicator, TwitterData, VideoData, NewsData, InformationWrapper, ButtonList, TrendingTopicsWrapper, TrendingTopicTitle, TrendingTopicsList, TopicRank, TopicName, TrendingTopic } from './styles';
 
 import InformationButton from '../../components/InformationButton'
 
@@ -23,19 +23,59 @@ export default function CurrentDayPost(){
         logoImage: newspaperLogo,
         buttonText: 'News',
     }
+
+    const trendingTopics =[
+        {
+            topic_position: 1,
+            topic_name: 'Dinis'
+        },
+        {
+            topic_position: 2,
+            topic_name: 'Yuri Alberto'
+        },
+        {
+            topic_position: 3,
+            topic_name: 'Claudinho'
+        },
+        {
+            topic_position: 4,
+            topic_name: 'Morumbi'
+        },
+        {
+            topic_position: 5,
+            topic_name: 'Daniel Alves'
+        },
+    ]
     
     return (
         <PostContent>
             <DateIndicator>NOW</DateIndicator>
-            <TwitterData data-testid="twitter-data">
-                <InformationButton {...twitterProps} />
-            </TwitterData>
-            <VideoData data-testid="video-data">
-                <InformationButton {...youtubeProps} />
-            </VideoData>
-            <NewsData data-testid="news-data">
-                <InformationButton {...newsProps} />
-            </NewsData>
+            <InformationWrapper>
+                <ButtonList>
+                    <TwitterData data-testid="twitter-data">
+                        <InformationButton {...twitterProps} />
+                    </TwitterData>
+                    <VideoData data-testid="video-data">
+                        <InformationButton {...youtubeProps} />
+                    </VideoData>
+                    <NewsData data-testid="news-data">
+                        <InformationButton {...newsProps} />
+                    </NewsData>
+                </ButtonList>
+                <TrendingTopicsWrapper>
+                    <TrendingTopicTitle>Top 5 trending topics</TrendingTopicTitle>
+                    <TrendingTopicsList>
+                        {trendingTopics.map(topic => {
+                            return (
+                                <TrendingTopic>
+                                    <TopicRank>{topic.topic_position}º</TopicRank>
+                                    <TopicName>{topic.topic_name}</TopicName>
+                                </TrendingTopic>
+                            )
+                        })}
+                    </TrendingTopicsList>
+                </TrendingTopicsWrapper>
+            </InformationWrapper>
         </PostContent>
     )
 }

--- a/src/pages/CurrentDayPost/styles.js
+++ b/src/pages/CurrentDayPost/styles.js
@@ -8,7 +8,7 @@ export const PostContent = styled.div`
     position: relative;
     top: 6vh;
     display: grid;
-    grid-template-columns: 8fr 14fr 14fr 14fr;
+    grid-template-columns: 1fr 4fr;
 `
 
 export const DateIndicator = styled.h1`
@@ -39,3 +39,50 @@ export const VideoData = styled.div`
 export const NewsData = styled.div`
     margin: 0 auto;
 `
+
+export const InformationWrapper = styled.div`
+    width: 100%;
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+    height: auto;
+`
+
+export const ButtonList = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    width: 100%;
+    align-items: center;
+`
+
+export const TrendingTopicsWrapper = styled.div`
+    display: grid;
+    grid-template-rows: 1fr 3fr;
+    align-items: flex-end;
+`
+
+export const TrendingTopicTitle = styled.h3`
+    font-size: 24px;
+    font-weight: bold;
+
+`
+
+export const TrendingTopicsList = styled.div`
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    font-size:20px;
+    padding: 20px;
+`
+
+export const TrendingTopic = styled.div`
+    display: grid;
+    grid-template-rows: 1fr 3fr;
+`
+
+export const TopicRank = styled.span`
+    font-weight: 700;
+`
+
+export const TopicName = styled.p`
+    font-weight: 400;
+`
+

--- a/src/pages/CurrentDayPost/tests/CurrentDayPost.test.js
+++ b/src/pages/CurrentDayPost/tests/CurrentDayPost.test.js
@@ -41,4 +41,14 @@ describe("Current day post", () => {
         const { getByText } = wrapper;
         getByText('News')
     })
+
+    it('renders trending topics', () => {
+        const { wrapper } = setup();
+        const { getByText } = wrapper;
+        getByText('Dinis')
+        getByText('Yuri Alberto')
+        getByText('Claudinho')
+        getByText('Morumbi')
+        getByText('Daniel Alves')
+    })
 })


### PR DESCRIPTION
# Changes Description
As in the first version of Diana we don't have any automation from the back end, we need to simplify the information about trending topics and other data (videos and news) to show on the current day post component. This way, instead of show the list of trends (bellow twitter's button), the number of videos about each topic (bellow video's button) and the updated date of the news of each topic (bellow news' button), we'll show just a ranked list of the trending topics selected for the current day.

https://user-images.githubusercontent.com/7401421/106386833-a564a900-63b5-11eb-97d6-5fcbbf2ef91c.mp4


Select the type of changes you're doing on project:

- [X] **Feature**
- [ ] **Change**
- [ ] **Fix**
- [ ] **Configuration**

# Solution Descripton
Created the ranked list of trending topics bellow the buttons on current day post component.

# Tests

- CurrentDayPost.test.js: Test it renders trending topics

# Task

Diana-web: [Task\_31](https://github.com/Try-tech-Labs/diana-web/issues/31)
